### PR TITLE
fix bpf compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.dylib
 *.dylib.dSYM
+*.so
 ggpack/test/out

--- a/bpf/anal_bpf.c
+++ b/bpf/anal_bpf.c
@@ -476,7 +476,7 @@ static int bpf_int_exit(RAnalEsil *esil, int interrupt) {
 static int esil_bpf_init (RAnalEsil *esil) {
 	if (!esil) return false;
 	// XXX. this is arbitrary!!
-	r_anal_esil_set_interrupt (esil, 0x0, bpf_int_exit);
+	r_anal_esil_set_interrupt (esil, bpf_int_exit);
 	return true;
 }
 
@@ -522,7 +522,6 @@ struct r_anal_plugin_t r_anal_plugin_bpf = {
 	.cmd_ext = NULL,
 	.esil_init = &esil_bpf_init,
 	.esil_post_loop = NULL,
-	.esil_intr = NULL,
 	.esil_trap = NULL,
 	.esil_fini = &esil_bpf_init
 

--- a/bpf/asm_bpf.c
+++ b/bpf/asm_bpf.c
@@ -657,9 +657,9 @@ static void lower_op(char *c) {
 #define R_TRUE 1
 static void normalize(RStrBuf* buf) {
 	int i;
-    char* buf_asm;
+        char* buf_asm;
 	if (!buf) return;
-    buf_asm = r_strbuf_get(buf);
+        buf_asm = r_strbuf_get(buf);
 
 	/* this normalization step is largely sub-optimal */
 
@@ -681,7 +681,7 @@ static void normalize(RStrBuf* buf) {
 	r_str_replace_in (buf_asm, (ut32)i, "%", "", R_TRUE);
 	r_str_replace_in (buf_asm, (ut32)i, "#", "", R_TRUE);
 	r_str_do_until_token (lower_op, buf_asm, '\0');
-    r_strbuf_set(buf, buf_asm);
+        r_strbuf_set(buf, buf_asm);
 
 }
 


### PR DESCRIPTION
In new r2 version, radare2 change rasmop->buf_asm as rstrbuf structure.